### PR TITLE
{CosmosDB} Add support for skip keys usage on key regeneration

### DIFF
--- a/src/cosmosdb-preview/HISTORY.rst
+++ b/src/cosmosdb-preview/HISTORY.rst
@@ -2,7 +2,7 @@
 Release History
 ===============
 
-1.6.3
+1.7.0
 +++++
 * Add ``--skip-account-keys-last-usage-check`` to ``az cosmosdb keys regenerate`` to optionally bypass the account keys last usage check during key regeneration.
 

--- a/src/cosmosdb-preview/HISTORY.rst
+++ b/src/cosmosdb-preview/HISTORY.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+1.6.3
++++++
+* Add ``--skip-account-keys-last-usage-check`` to ``az cosmosdb keys regenerate`` to optionally bypass the account keys last usage check during key regeneration.
+
 1.6.2
 * Added throughput bucketing.
 +++++++

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -1851,7 +1851,7 @@ short-summary: Regenerate an access key for a Azure Cosmos DB database account.
 parameters:
   - name: --key-kind
     short-summary: The access key to regenerate.
-  - name: --skip-account-keys-last-usage-check
+  - name: --skip-account-keys-last-usage-check --skip-usage-check
     short-summary: Skip the account keys last usage check that blocks key regeneration when the key was recently used.
 examples:
   - name: Regenerate an access key for a Azure Cosmos DB database account.

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -1851,7 +1851,7 @@ short-summary: Regenerate an access key for a Azure Cosmos DB database account.
 parameters:
   - name: --key-kind
     short-summary: The access key to regenerate.
-  - name: --skip-account-keys-last-usage-check --skip-usage-check
+  - name: --skip-safe-rotation
     short-summary: Skip the account keys last usage check that blocks key regeneration when the key was recently used.
 examples:
   - name: Regenerate an access key for a Azure Cosmos DB database account.
@@ -1859,5 +1859,5 @@ examples:
       az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary
   - name: Regenerate an access key, skipping the account keys last usage check.
     text: |
-      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary --skip-account-keys-last-usage-check true
+      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary --skip-safe-rotation true
 """

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -1844,3 +1844,20 @@ helps['cosmosdb fleet analytics delete'] = """
 type: command
 short-summary: Delete a Fleet Analytics resource from a Fleet.
 """
+
+helps['cosmosdb keys regenerate'] = """
+type: command
+short-summary: Regenerate an access key for a Azure Cosmos DB database account.
+parameters:
+  - name: --key-kind
+    short-summary: The access key to regenerate.
+  - name: --skip-account-keys-last-usage-check
+    short-summary: Skip the account keys last usage check that blocks key regeneration when the key was recently used.
+examples:
+  - name: Regenerate an access key for a Azure Cosmos DB database account.
+    text: |
+      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary
+  - name: Regenerate an access key, skipping the account keys last usage check.
+    text: |
+      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary --skip-account-keys-last-usage-check true
+"""

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -55,6 +55,7 @@ from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
     BackupStorageRedundancy,
     CapacityMode,
     ContinuousTier,
+    KeyKind,
     DefaultPriorityLevel)
 
 from azure.cli.core.util import shell_safe_json_parse
@@ -433,6 +434,11 @@ def load_arguments(self, _):
     with self.argument_context('cosmosdb') as c:
         c.argument('account_name', arg_type=name_type, help='Name of the Cosmos DB database account', completer=get_resource_name_completion_list('Microsoft.DocumentDb/databaseAccounts'), id_part='name')
         c.argument('database_id', options_list=['--db-name', '-d'], help='Database Name')
+
+    with self.argument_context('cosmosdb keys regenerate') as c:
+        c.argument('account_name', account_name_type, id_part=None)
+        c.argument('key_kind', arg_type=get_enum_type(KeyKind), help="The access key to regenerate.")
+        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-account-keys-last-usage-check'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
 
     # CosmosDB account create with gremlin and tables to restore
     with self.argument_context('cosmosdb create') as c:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -436,9 +436,8 @@ def load_arguments(self, _):
         c.argument('database_id', options_list=['--db-name', '-d'], help='Database Name')
 
     with self.argument_context('cosmosdb keys regenerate') as c:
-        c.argument('account_name', account_name_type, id_part=None)
         c.argument('key_kind', arg_type=get_enum_type(KeyKind), help="The access key to regenerate.")
-        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-account-keys-last-usage-check'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
+        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-account-keys-last-usage-check', '--skip-usage-check'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
 
     # CosmosDB account create with gremlin and tables to restore
     with self.argument_context('cosmosdb create') as c:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -437,7 +437,7 @@ def load_arguments(self, _):
 
     with self.argument_context('cosmosdb keys regenerate') as c:
         c.argument('key_kind', arg_type=get_enum_type(KeyKind), help="The access key to regenerate.")
-        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-account-keys-last-usage-check', '--skip-usage-check'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
+        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-safe-rotation'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
 
     # CosmosDB account create with gremlin and tables to restore
     with self.argument_context('cosmosdb create') as c:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
@@ -230,6 +230,9 @@ def load_command_table(self, _):
         g.custom_command('list', 'cli_cosmosdb_list')
         g.show_command('show', 'get')
 
+    with self.command_group('cosmosdb keys', cosmosdb_sdk, client_factory=cf_db_accounts) as g:
+        g.custom_command('regenerate', 'cli_cosmosdb_keys_regenerate')
+
     with self.command_group('cosmosdb sql restorable-container', cosmosdb_restorable_sql_containers_sdk, client_factory=cf_restorable_sql_containers, is_preview=True) as g:
         g.command('list', 'list')
 

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
@@ -1837,12 +1837,6 @@ def cli_begin_mongo_db_database_partition_merge(client,
     return async_partition_merge_result.result()
 
 
-def _handle_exists_exception(http_response_error):
-    if http_response_error.status_code == 404:
-        return False
-    raise http_response_error
-
-
 def process_restorable_databases(restorable_databases, database_name):
     latest_database_delete_time = datetime.datetime.utcfromtimestamp(0)
     latest_database_create_or_recreate_time = datetime.datetime.utcfromtimestamp(0)

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
@@ -28,6 +28,7 @@ from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
     ContinuousModeProperties,
     DatabaseAccountCreateUpdateParameters,
     MergeParameters,
+    DatabaseAccountRegenerateKeyParameters,
     RetrieveThroughputParameters,
     RetrieveThroughputPropertiesResource,
     PhysicalPartitionId,
@@ -1355,6 +1356,18 @@ def cli_cosmosdb_list(client, resource_group_name=None):
         return client.list_by_resource_group(resource_group_name)
 
     return client.list()
+
+
+def cli_cosmosdb_keys_regenerate(client,
+                                 resource_group_name,
+                                 account_name,
+                                 key_kind,
+                                 skip_account_keys_last_usage_check=None):
+    """ Regenerates an access key for a Azure Cosmos DB database account. """
+    key_to_regenerate = DatabaseAccountRegenerateKeyParameters(
+        key_kind=key_kind,
+        skip_account_keys_last_usage_check=skip_account_keys_last_usage_check)
+    return client.begin_regenerate_key(resource_group_name, account_name, key_to_regenerate)
 
 
 # latest restorable timestamp for gremlin graph and table

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb_keys_regenerate.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb_keys_regenerate.py
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
+    DatabaseAccountRegenerateKeyParameters,
+    KeyKind,
+)
+
+
+class CosmosDBKeysRegenerateBodyTest(unittest.TestCase):
+    """Validate the regenerate-key request body honors the backend wire contract.
+
+    The Cosmos DB RP reads the PascalCase property ``SkipAccountKeysLastUsageCheck``
+    from the request body. The property must be omitted entirely when the CLI flag
+    is not supplied so existing behavior is unchanged.
+    """
+
+    def test_skip_check_omitted_when_not_specified(self):
+        params = DatabaseAccountRegenerateKeyParameters(key_kind=KeyKind.PRIMARY)
+        body = params.serialize()
+        self.assertEqual(body, {"keyKind": "primary"})
+        self.assertNotIn("SkipAccountKeysLastUsageCheck", body)
+
+    def test_skip_check_true(self):
+        params = DatabaseAccountRegenerateKeyParameters(
+            key_kind=KeyKind.PRIMARY, skip_account_keys_last_usage_check=True)
+        body = params.serialize()
+        self.assertEqual(body.get("SkipAccountKeysLastUsageCheck"), True)
+
+    def test_skip_check_false(self):
+        params = DatabaseAccountRegenerateKeyParameters(
+            key_kind=KeyKind.SECONDARY, skip_account_keys_last_usage_check=False)
+        body = params.serialize()
+        self.assertEqual(body.get("SkipAccountKeysLastUsageCheck"), False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/vendored_sdks/azure_mgmt_cosmosdb/models/_models_py3.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/vendored_sdks/azure_mgmt_cosmosdb/models/_models_py3.py
@@ -6177,6 +6177,9 @@ class DatabaseAccountRegenerateKeyParameters(_serialization.Model):
     :ivar key_kind: The access key to regenerate. Required. Known values are: "primary",
      "secondary", "primaryReadonly", and "secondaryReadonly".
     :vartype key_kind: str or ~azure.mgmt.cosmosdb.models.KeyKind
+    :ivar skip_account_keys_last_usage_check: Whether to skip the account keys last usage check
+     that blocks key regeneration when the key was recently used.
+    :vartype skip_account_keys_last_usage_check: bool
     """
 
     _validation = {
@@ -6185,16 +6188,27 @@ class DatabaseAccountRegenerateKeyParameters(_serialization.Model):
 
     _attribute_map = {
         "key_kind": {"key": "keyKind", "type": "str"},
+        "skip_account_keys_last_usage_check": {"key": "SkipAccountKeysLastUsageCheck", "type": "bool"},
     }
 
-    def __init__(self, *, key_kind: Union[str, "_models.KeyKind"], **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        key_kind: Union[str, "_models.KeyKind"],
+        skip_account_keys_last_usage_check: Optional[bool] = None,
+        **kwargs: Any
+    ) -> None:
         """
         :keyword key_kind: The access key to regenerate. Required. Known values are: "primary",
          "secondary", "primaryReadonly", and "secondaryReadonly".
         :paramtype key_kind: str or ~azure.mgmt.cosmosdb.models.KeyKind
+        :keyword skip_account_keys_last_usage_check: Whether to skip the account keys last usage
+         check that blocks key regeneration when the key was recently used.
+        :paramtype skip_account_keys_last_usage_check: bool
         """
         super().__init__(**kwargs)
         self.key_kind = key_kind
+        self.skip_account_keys_last_usage_check = skip_account_keys_last_usage_check
 
 
 class DatabaseAccountsListResult(_serialization.Model):

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.6.2'
+VERSION = '1.6.3'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.7.30'
+VERSION = '1.7.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.6.3'
+VERSION = '1.7.30'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Adds support for skipping keys usage during CosmosDB account key regeneration in the `cosmosdb-preview` extension.

### Changes
- New command wiring in `commands.py` and custom implementation in `custom.py`
- New `_params.py` / `_help.py` entries
- Model update in `azure_mgmt_cosmosdb/models/_models_py3.py`
- Test coverage in `tests/latest/test_cosmosdb_keys_regenerate.py`
- `HISTORY.rst` and `setup.py` version bump