### PR TITLE
{CosmosDB} Add --skip-safe-rotation to az cosmosdb keys regenerate

### DIFF
--- a/src/cosmosdb-preview/HISTORY.rst
+++ b/src/cosmosdb-preview/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 
 1.7.0
 ++++++
+* Add ``--skip-safe-rotation`` to ``az cosmosdb keys regenerate`` to optionally bypass the account keys last usage check during key regeneration.
 * Add support for soft-deleted resource operations for SQL API
 * New command group `az cosmosdb softdeleted-account` to list, show, delete (purge), and recover soft-deleted accounts
 * New command group `az cosmosdb sql softdeleted-database` to list, show, delete (purge), and recover soft-deleted databases

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_help.py
@@ -1974,3 +1974,20 @@ examples:
     text: |
       az cosmosdb sql softdeleted-container recover --location westus --account-name MyAccount --database-name MyDatabase --name MyContainer --resource-group MyResourceGroup
 """
+
+helps['cosmosdb keys regenerate'] = """
+type: command
+short-summary: Regenerate an access key for a Azure Cosmos DB database account.
+parameters:
+  - name: --key-kind
+    short-summary: The access key to regenerate.
+  - name: --skip-safe-rotation
+    short-summary: Skip the account keys last usage check that blocks key regeneration when the key was recently used.
+examples:
+  - name: Regenerate an access key for a Azure Cosmos DB database account.
+    text: |
+      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary
+  - name: Regenerate an access key, skipping the account keys last usage check.
+    text: |
+      az cosmosdb keys regenerate --resource-group MyResourceGroup --name MyAccount --key-kind primary --skip-safe-rotation true
+"""

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/_params.py
@@ -56,6 +56,7 @@ from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
     BackupStorageRedundancy,
     CapacityMode,
     ContinuousTier,
+    KeyKind,
     DefaultPriorityLevel)
 
 from azure.cli.core.util import shell_safe_json_parse
@@ -434,6 +435,10 @@ def load_arguments(self, _):
     with self.argument_context('cosmosdb') as c:
         c.argument('account_name', arg_type=name_type, help='Name of the Cosmos DB database account', completer=get_resource_name_completion_list('Microsoft.DocumentDb/databaseAccounts'), id_part='name')
         c.argument('database_id', options_list=['--db-name', '-d'], help='Database Name')
+
+    with self.argument_context('cosmosdb keys regenerate') as c:
+        c.argument('key_kind', arg_type=get_enum_type(KeyKind), help="The access key to regenerate.")
+        c.argument('skip_account_keys_last_usage_check', options_list=['--skip-safe-rotation'], arg_type=get_three_state_flag(), is_preview=True, help="Skip the account keys last usage check that blocks key regeneration when the key was recently used.")
 
     # CosmosDB account create with gremlin and tables to restore
     with self.argument_context('cosmosdb create') as c:

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/commands.py
@@ -246,6 +246,9 @@ def load_command_table(self, _):
         g.custom_command('list', 'cli_cosmosdb_list')
         g.show_command('show', 'get')
 
+    with self.command_group('cosmosdb keys', cosmosdb_sdk, client_factory=cf_db_accounts) as g:
+        g.custom_command('regenerate', 'cli_cosmosdb_keys_regenerate')
+
     with self.command_group('cosmosdb sql restorable-container', cosmosdb_restorable_sql_containers_sdk, client_factory=cf_restorable_sql_containers, is_preview=True) as g:
         g.command('list', 'list')
 

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/custom.py
@@ -28,6 +28,7 @@ from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
     ContinuousModeProperties,
     DatabaseAccountCreateUpdateParameters,
     MergeParameters,
+    DatabaseAccountRegenerateKeyParameters,
     RetrieveThroughputParameters,
     RetrieveThroughputPropertiesResource,
     PhysicalPartitionId,
@@ -1398,6 +1399,18 @@ def _create_database_account(client,
     docdb_account = async_docdb_create.result()
     docdb_account = client.get(resource_group_name, account_name)  # Workaround
     return docdb_account
+
+
+def cli_cosmosdb_keys_regenerate(client,
+                                 resource_group_name,
+                                 account_name,
+                                 key_kind,
+                                 skip_account_keys_last_usage_check=None):
+    """ Regenerates an access key for a Azure Cosmos DB database account. """
+    key_to_regenerate = DatabaseAccountRegenerateKeyParameters(
+        key_kind=key_kind,
+        skip_account_keys_last_usage_check=skip_account_keys_last_usage_check)
+    return client.begin_regenerate_key(resource_group_name, account_name, key_to_regenerate)
 
 
 def cli_cosmosdb_list(client, resource_group_name=None):

--- a/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb_keys_regenerate.py
+++ b/src/cosmosdb-preview/azext_cosmosdb_preview/tests/latest/test_cosmosdb_keys_regenerate.py
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+from azext_cosmosdb_preview.vendored_sdks.azure_mgmt_cosmosdb.models import (
+    DatabaseAccountRegenerateKeyParameters,
+    KeyKind,
+)
+
+
+class CosmosDBKeysRegenerateBodyTest(unittest.TestCase):
+    """Validate the regenerate-key request body honors the backend wire contract.
+
+    The generated Cosmos DB SDK serializes the optional flag as the camelCase
+    property ``skipAccountKeysLastUsageCheck``. The property must be omitted
+    entirely when the CLI flag is not supplied so existing behavior is unchanged.
+    """
+
+    def test_skip_check_omitted_when_not_specified(self):
+        params = DatabaseAccountRegenerateKeyParameters(key_kind=KeyKind.PRIMARY)
+        body = params.serialize()
+        self.assertEqual(body, {"keyKind": "primary"})
+        self.assertNotIn("skipAccountKeysLastUsageCheck", body)
+
+    def test_skip_check_true(self):
+        params = DatabaseAccountRegenerateKeyParameters(
+            key_kind=KeyKind.PRIMARY, skip_account_keys_last_usage_check=True)
+        body = params.serialize()
+        self.assertEqual(body.get("skipAccountKeysLastUsageCheck"), True)
+
+    def test_skip_check_false(self):
+        params = DatabaseAccountRegenerateKeyParameters(
+            key_kind=KeyKind.SECONDARY, skip_account_keys_last_usage_check=False)
+        body = params.serialize()
+        self.assertEqual(body.get("skipAccountKeysLastUsageCheck"), False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cosmosdb-preview/setup.py
+++ b/src/cosmosdb-preview/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 # TODO: Confirm this is the right version number you want and it matches your
 # HISTORY.rst entry.
-VERSION = '1.6.2'
+VERSION = '1.7.0'
 
 # The full list of classifiers is available at
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Ports the `--skip-safe-rotation` flag for `az cosmosdb keys regenerate` (originally PR #9, which was mistakenly targeted at `main`) onto the `cdb260401preview` branch that carries the regenerated 2026-04-01-preview SDK.

### Conflict resolution
- Dropped the manual `_models_py3.py` edit — the regenerated SDK on this branch already defines `skip_account_keys_last_usage_check` (serialized as camelCase `skipAccountKeysLastUsageCheck`).
- Aligned the unit tests to the generated wire contract (camelCase).
- Folded the changelog entry into the existing `1.7.0` section and set `setup.py` version to `1.7.0`.

### Validation
- `py_compile` + module imports OK.
- All 3 unit tests in `test_cosmosdb_keys_regenerate.py` pass locally (Azure CLI bundled Python 3.12).
- 
<img width="2550" height="1803" alt="image" src="https://github.com/user-attachments/assets/790241ba-c3bc-45fb-ac84-fb64f7920a3f" />
